### PR TITLE
Feature/flyway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle
+
+.vscode

--- a/drive/build.gradle
+++ b/drive/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.flywaydb:flyway-database-postgresql:11.8.2'
+        classpath 'org.postgresql:postgresql:42.7.5'
+    }
+}
+
+plugins {
+    id 'org.flywaydb.flyway' version '11.8.2'
+}
+
+flyway {
+    url = System.getenv('FLYWAY_DB') ?: 'jdbc:postgresql://localhost:5432/drive'
+    user = System.getenv('FLYWAY_USER') ?: 'drive'
+    password = System.getenv('FLYWAY_PASS') ?: 'drive'
+    locations = ['filesystem:db/migration']
+    cleanDisabled = true
+}

--- a/drive/db/migration/V1__initial.sql
+++ b/drive/db/migration/V1__initial.sql
@@ -1,0 +1,51 @@
+CREATE TABLE files (
+    id UUID NOT NULL,
+    owner_id VARCHAR(255) NOT NULL,
+    folder_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    content_type VARCHAR(255) NOT NULL,
+    content_location VARCHAR(255) NOT NULL,
+    content_size BIGINT NOT NULL,
+    created_at TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE folders (
+    id UUID NOT NULL,
+    is_root_folder BOOLEAN NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    owner_id VARCHAR(255) NOT NULL,
+    parent_folder_id UUID,
+    created_at TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP(6) WITH TIME ZONE,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE members (
+    id VARCHAR(255) NOT NULL,
+    username VARCHAR(255),
+    nickname VARCHAR(255),
+    quota_ammount BIGINT NOT NULL,
+    quota_unit VARCHAR(255) NOT NULL CHECK (quota_unit IN ('BYTE', 'KILOBYTE', 'MEGABYTE', 'GIGABYTE', 'TERABYTE')),
+    quota_request_ammount BIGINT,
+    quota_request_unit VARCHAR(255) CHECK (quota_request_unit IN ('BYTE', 'KILOBYTE', 'MEGABYTE', 'GIGABYTE', 'TERABYTE')),
+    quota_requested_at TIMESTAMP(6) WITH TIME ZONE,
+    created_at TIMESTAMP(6) WITH TIME ZONE,
+    updated_at TIMESTAMP(6) WITH TIME ZONE,
+    synchronized_version BIGINT,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE sub_folders (
+    parent_folder_id UUID NOT NULL,
+    sub_folder_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (parent_folder_id, sub_folder_id)
+);
+
+ALTER TABLE IF EXISTS sub_folders
+    ADD CONSTRAINT fk_sub_folders_parent_folder_id
+    FOREIGN KEY (parent_folder_id)
+    REFERENCES folders;

--- a/drive/db/migration/V2__has_system_access_column.sql
+++ b/drive/db/migration/V2__has_system_access_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE members
+    ADD COLUMN has_system_access BOOLEAN NOT NULL DEFAULT FALSE;

--- a/member/build.gradle
+++ b/member/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.flywaydb:flyway-database-postgresql:11.8.2'
+        classpath 'org.postgresql:postgresql:42.7.5'
+    }
+}
+
+plugins {
+    id 'org.flywaydb.flyway' version '11.8.2'
+}
+
+flyway {
+    url = System.getenv('FLYWAY_DB') ?: 'jdbc:postgresql://localhost:5432/member'
+    user = System.getenv('FLYWAY_USER') ?: 'member'
+    password = System.getenv('FLYWAY_PASS') ?: 'member'
+    locations = ['filesystem:db/migration']
+    cleanDisabled = true
+}

--- a/member/db/migration/V1__initial.sql
+++ b/member/db/migration/V1__initial.sql
@@ -1,0 +1,27 @@
+CREATE TABLE systems (
+    system VARCHAR(30) NOT NULL CHECK (system IN ('DRIVE','MEMBER')),
+    PRIMARY KEY (system)
+);
+
+CREATE TABLE members (
+    id VARCHAR(255) NOT NULL,
+    active BOOLEAN NOT NULL,
+    created_at TIMESTAMP(6) WITH TIME ZONE,
+    updated_at TIMESTAMP(6) WITH TIME ZONE,
+    email VARCHAR(255),
+    nickname VARCHAR(255),
+    username VARCHAR(255),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE member_system (
+    member_id VARCHAR(255) NOT NULL,
+    system_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (member_id, system_id)
+);
+
+ALTER TABLE member_system
+    ADD CONSTRAINT fk_member_system_system_id FOREIGN KEY (system_id) REFERENCES systems(system);
+
+ALTER TABLE member_system
+    ADD CONSTRAINT fk_member_system_member_id FOREIGN KEY (member_id) REFERENCES members(id);

--- a/member/db/migration/V2__insert_initial_systems.sql
+++ b/member/db/migration/V2__insert_initial_systems.sql
@@ -1,0 +1,3 @@
+INSERT INTO systems (system) VALUES 
+    ('DRIVE'),
+    ('MEMBER');

--- a/member/db/migration/V3__synchronized_version_column.sql
+++ b/member/db/migration/V3__synchronized_version_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE members
+    ADD COLUMN synchronized_version BIGINT NOT NULL DEFAULT 0;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'infrastructure'
+include('member', 'drive')


### PR DESCRIPTION
This pull request introduces Flyway database migration support for two modules, `drive` and `member`, and sets up initial database schemas and configurations. The most important changes include configuring Flyway for both modules, defining initial database schemas, and adding new migration scripts for schema updates.

### Flyway Configuration:

* [`drive/build.gradle`](diffhunk://#diff-fcfdf9ff39c28079ebf641e3438de8d1b0f711474d4fb721c504f086f579a6edR1-R21): Configured Flyway for the `drive` module, including database connection settings and migration file locations.
* [`member/build.gradle`](diffhunk://#diff-77aaac44af0c1c1f24508753f7fb3f3fed573d01405fc5e5c5670a762c722f9fR1-R21): Configured Flyway for the `member` module with similar settings as the `drive` module.

### Initial Database Schemas:

* [`drive/db/migration/V1__initial.sql`](diffhunk://#diff-59add5c9ef569917e7ee1e1760b538db6eb6be69ad65f4df37089dd0c8db4693R1-R51): Created tables for `files`, `folders`, `members`, and `sub_folders` in the `drive` module, along with primary keys and foreign key constraints.
* [`member/db/migration/V1__initial.sql`](diffhunk://#diff-e9236e8dad42d184c137bb08f03777638ec1e2ab5885cb28f4aedfacf9fd475eR1-R27): Created tables for `systems`, `members`, and `member_system` in the `member` module, including primary keys and foreign key relationships.

### Schema Updates:

* [`drive/db/migration/V2__has_system_access_column.sql`](diffhunk://#diff-fdba531e3338ef1e6dfdf77b54e5d8ab009b40409a7a623b761f961f54a7fd08R1-R2): Added a `has_system_access` column to the `members` table in the `drive` module.
* [`member/db/migration/V2__insert_initial_systems.sql`](diffhunk://#diff-beaa790a20a9d76b299ad80f51c18799cda859011038a850c6041d4240291b9cR1-R3): Inserted initial data into the `systems` table in the `member` module.
* [`member/db/migration/V3__synchronized_version_column.sql`](diffhunk://#diff-2aee38bc059b2e7d97ada6477d6200221245ab750c33c1bbecd0cb568d78bca9R1-R2): Added a `synchronized_version` column to the `members` table in the `member` module.

### Project Setup:

* [`settings.gradle`](diffhunk://#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30deR1-R2): Configured the root project name as `infrastructure` and included the `member` and `drive` modules.