### PR TITLE
feat: add migration script to drop sub_folders table

### DIFF
--- a/drive/db/migration/V3__drop_table_sub_folders.sql
+++ b/drive/db/migration/V3__drop_table_sub_folders.sql
@@ -1,0 +1,1 @@
+DROP TABLE sub_folders;


### PR DESCRIPTION
This pull request includes a single change to the database migration file `V3__drop_table_sub_folders.sql`. The change drops the `sub_folders` table from the database.