### PR TITLE
Feature/drive quota in bytes

### DIFF
--- a/drive/db/migration/V4__fix_typo.sql
+++ b/drive/db/migration/V4__fix_typo.sql
@@ -1,0 +1,5 @@
+ALTER TABLE members
+RENAME COLUMN quota_ammount TO quota_amount;
+
+ALTER TABLE members
+RENAME COLUMN quota_request_ammount TO quota_request_amount;

--- a/drive/db/migration/V5__quota_in_bytes.sql
+++ b/drive/db/migration/V5__quota_in_bytes.sql
@@ -1,0 +1,25 @@
+ALTER TABLE members
+    ADD COLUMN quota_in_bytes BIGINT NOT NULL DEFAULT 0;
+
+UPDATE members
+SET quota_in_bytes = CASE
+    WHEN quota_unit = 'BYTE' THEN quota_amount
+    WHEN quota_unit = 'KILOBYTE' THEN quota_amount * 1024
+    WHEN quota_unit = 'MEGABYTE' THEN quota_amount * 1024 * 1024
+    WHEN quota_unit = 'GIGABYTE' THEN quota_amount * 1024 * 1024 * 1024
+    WHEN quota_unit = 'TERABYTE' THEN quota_amount * 1024 * 1024 * 1024 * 1024
+    ELSE 0
+END;
+
+ALTER TABLE members
+    ADD COLUMN quota_request_in_bytes BIGINT;
+
+UPDATE members
+SET quota_request_in_bytes = CASE
+    WHEN quota_request_unit = 'BYTE' THEN quota_request_amount
+    WHEN quota_request_unit = 'KILOBYTE' THEN quota_request_amount * 1024
+    WHEN quota_request_unit = 'MEGABYTE' THEN quota_request_amount * 1024 * 1024
+    WHEN quota_request_unit = 'GIGABYTE' THEN quota_request_amount * 1024 * 1024 * 1024
+    WHEN quota_request_unit = 'TERABYTE' THEN quota_request_amount * 1024 * 1024 * 1024 * 1024
+    ELSE NULL
+END;


### PR DESCRIPTION
This pull request updates the database schema for the `members` table to fix column name typos and introduce new columns that store quota values in bytes for easier computation and consistency. The changes ensure that both quota and quota request amounts are available in a standardized unit (bytes), improving future data handling and queries.

Schema corrections:

* Renamed columns `quota_ammount` to `quota_amount` and `quota_request_ammount` to `quota_request_amount` in the `members` table to fix spelling errors.

Quota standardization:

* Added a new `quota_in_bytes` column (type `BIGINT`, not null, default 0) to the `members` table and populated it by converting existing `quota_amount` values based on their unit.
* Added a new `quota_request_in_bytes` column (type `BIGINT`, nullable) to the `members` table and populated it by converting existing `quota_request_amount` values based on their unit.